### PR TITLE
add H2 database to test module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+	runtimeOnly('com.h2database:h2')
 
 	annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,4 @@
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=FALSE
+spring.datasource.username=sa
+spring.datasource.password=sa


### PR DESCRIPTION
- added a dependency on H2 database in the 'build.gradle' file.
- Configured access to the H2 database in the `application.properties` file.